### PR TITLE
fix: NCF_model args namespace error # 18

### DIFF
--- a/src/models/NCF/NCF_model.py
+++ b/src/models/NCF/NCF_model.py
@@ -77,10 +77,10 @@ class NeuralCollaborativeFiltering(nn.Module):
         self.field_dims = data['field_dims']
         self.user_field_idx = np.array((0, ), dtype=np.int32)
         self.item_field_idx = np.array((1, ), dtype=np.int32)
-        self.embedding = FeaturesEmbedding(self.field_dims, args.embedding_dim)
-        self.embed_output_dim = len(self.field_dims) * args.embedding_dim
+        self.embedding = FeaturesEmbedding(self.field_dims, args.embed_dim)
+        self.embed_output_dim = len(self.field_dims) * args.embed_dim
         self.mlp = MultiLayerPerceptron(self.embed_output_dim, args.mlp_dims, args.dropout, output_layer=False)
-        self.fc = torch.nn.Linear(args.mlp_dims[-1] + args.embedding_dim, 1)
+        self.fc = torch.nn.Linear(args.mlp_dims[-1] + args.embed_dim, 1)
 
 
     def forward(self, x):


### PR DESCRIPTION
## Overview
- NCF 모델에서 embed args 부분에서 Namespace 에러 수정했습니다.

## Change Log
-

## To Reviewer
- args.embedding_dim -> args.embed_dim으로 입력받는 args인자 이름에 맞게 수정했습니다.

## Issue Tags
- Closed | Fixed: #18 
- See also: #15 