### PR TITLE
Feat: DeepFFM 모델 구현 및 실험 #52

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def main(args):
 
     ######################## DATA LOAD
     print(f'--------------- {args.model} Load Data ---------------')
-    if args.model in ('FM', 'FFM'):
+    if args.model in ('FM', 'FFM', 'DeepFFM'):
         data = context_data_load(args)
     elif args.model in ('NCF', 'WDN', 'DCN'):
         data = dl_data_load(args)
@@ -35,7 +35,7 @@ def main(args):
 
     ######################## Train/Valid Split
     print(f'--------------- {args.model} Train/Valid Split ---------------')
-    if args.model in ('FM', 'FFM'):
+    if args.model in ('FM', 'FFM', 'DeepFFM'):
         data = context_data_split(args, data)
         data = context_data_loader(args, data)
 
@@ -108,7 +108,7 @@ def main(args):
     ######################## SAVE PREDICT
     print(f'--------------- SAVE {args.model} PREDICT ---------------')
     submission = pd.read_csv(args.data_path + 'sample_submission.csv')
-    if args.model in ('FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'CatBoost'):
+    if args.model in ('FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'CatBoost', 'DeepFFM'):
         submission['rating'] = predicts
     else:
         pass
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     ############### BASIC OPTION
     arg('--data_path', type=str, default='data/', help='Data path를 설정할 수 있습니다.')
     arg('--saved_model_path', type=str, default='./saved_models', help='Saved Model path를 설정할 수 있습니다.')
-    arg('--model', type=str, choices=['FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'CatBoost'],
+    arg('--model', type=str, choices=['FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'CatBoost', 'DeepFFM'],
                                 help='학습 및 예측할 모델을 선택할 수 있습니다.')
     arg('--data_shuffle', type=bool, default=True, help='데이터 셔플 여부를 조정할 수 있습니다.')
     arg('--test_size', type=float, default=0.2, help='Train/Valid split 비율을 조정할 수 있습니다.')
@@ -152,9 +152,9 @@ if __name__ == "__main__":
 
 
     ############### FM, FFM, NCF, WDN, DCN Common OPTION
-    arg('--embed_dim', type=int, default=16, help='FM, FFM, NCF, WDN, DCN에서 embedding시킬 차원을 조정할 수 있습니다.')
-    arg('--dropout', type=float, default=0.2, help='NCF, WDN, DCN에서 Dropout rate를 조정할 수 있습니다.')
-    arg('--mlp_dims', type=parse_args, default=(16, 16), help='NCF, WDN, DCN에서 MLP Network의 차원을 조정할 수 있습니다.')
+    arg('--embed_dim', type=int, default=16, help='FM, FFM, NCF, WDN, DCN, DeepFFM에서 embedding시킬 차원을 조정할 수 있습니다.')
+    arg('--dropout', type=float, default=0.2, help='NCF, WDN, DCN, DeepFFM에서 Dropout rate를 조정할 수 있습니다.')
+    arg('--mlp_dims', type=parse_args, default=(16, 16), help='NCF, WDN, DCN, DeepFFM에서 MLP Network의 차원을 조정할 수 있습니다.')
 
 
     ############### DCN

--- a/src/models/DeepFFM/DeepFFM_model.py
+++ b/src/models/DeepFFM/DeepFFM_model.py
@@ -70,7 +70,7 @@ class DeepFFM(nn.Module):
     def forward(self, x: torch.Tensor):
         x = x + x.new_tensor(self.offsets, dtype= torch.int32).unsqueeze(0)
         xs = [self.embeddings[i](x) for i in range(self.num_fields)]
-        avg_xs = torch.stack(xs, dim=0).sum(dim=0)
+        avg_xs = torch.stack(xs, dim=0).mean(dim=0)
         mlp_xs = torch.cat([avg_xs[:, i, :] for i in range(avg_xs.size(1))], dim=1)
         ffm_term = torch.sum(torch.sum(self.ffm(xs), dim=1), dim=1, keepdim=True)
         

--- a/src/models/DeepFFM/DeepFFM_model.py
+++ b/src/models/DeepFFM/DeepFFM_model.py
@@ -10,8 +10,10 @@ class FeaturesLinear(nn.Module):
         self.fc = torch.nn.Embedding(sum(field_dims), output_dim)
         self.bias = torch.nn.Parameter(torch.zeros((output_dim,)))
 
+
     def forward(self, x: torch.Tensor):
         return torch.sum(self.fc(x), dim=1) + self.bias
+
 
 # FFM모델을 구현합니다.
 # feature간의 상호작용을 파악하기 위해서 잠재백터를 두는 과정을 보여줍니다.
@@ -47,6 +49,7 @@ class MultiLayerPerceptron(nn.Module):
     def forward(self, x):
         return self.mlp(x)
 
+
 # 최종적인 DeepFFM모델입니다.
 # 각 필드별로 곱해져 계산된 embedding 결과를 합하고, 마지막으로 embedding 결과를 합하여 마무리합니다.
 class DeepFFM(nn.Module):
@@ -58,6 +61,7 @@ class DeepFFM(nn.Module):
         self.linear = FeaturesLinear(self.field_dims)
         self.ffm = FieldAwareFactorizationMachine(self.field_dims, args.embed_dim)
         self.offsets = np.array((0, *np.cumsum(self.field_dims)[:-1]), dtype=np.int32)
+
         # 각 field에 대한 임베딩 레이어를 담은 리스트
         self.embeddings = torch.nn.ModuleList([
             torch.nn.Embedding(self.input_dim, args.embed_dim) for _ in range(self.num_fields)
@@ -66,6 +70,7 @@ class DeepFFM(nn.Module):
 
         self.embed_output_dim = len(self.field_dims) * args.embed_dim
         self.mlp = MultiLayerPerceptron(self.embed_output_dim, args.mlp_dims, args.dropout)
+
 
     def forward(self, x: torch.Tensor):
         x = x + x.new_tensor(self.offsets, dtype= torch.int32).unsqueeze(0)

--- a/src/models/FFM/DeepFFM_model.py
+++ b/src/models/FFM/DeepFFM_model.py
@@ -32,3 +32,22 @@ class FieldAwareFactorizationMachine(nn.Module):
         ix = [xs[j][:, i] * xs[i][:, j] for i in range(self.num_fields - 1) for j in range(i + 1, self.num_fields)]
         ix = torch.stack(ix, dim=1)
         return ix
+
+# MLP을 구현합니다.
+class MultiLayerPerceptron(nn.Module):
+    def __init__(self, input_dim, embed_dims, dropout, output_layer=True):
+        super().__init__()
+        layers = list()
+        for embed_dim in embed_dims:
+            layers.append(torch.nn.Linear(input_dim, embed_dim))
+            layers.append(torch.nn.BatchNorm1d(embed_dim))
+            layers.append(torch.nn.ReLU())
+            layers.append(torch.nn.Dropout(p=dropout))
+            input_dim = embed_dim
+        if output_layer:
+            layers.append(torch.nn.Linear(input_dim, 1))
+        self.mlp = torch.nn.Sequential(*layers)
+
+
+    def forward(self, x):
+        return self.mlp(x)

--- a/src/models/FFM/DeepFFM_model.py
+++ b/src/models/FFM/DeepFFM_model.py
@@ -12,3 +12,23 @@ class FeaturesLinear(nn.Module):
 
     def forward(self, x: torch.Tensor):
         return torch.sum(self.fc(x), dim=1) + self.bias
+
+# FFM모델을 구현합니다.
+# feature간의 상호작용을 파악하기 위해서 잠재백터를 두는 과정을 보여줍니다.
+# FFM은 FM과 다르게 필드별로 여러개의 잠재백터를 가지므로 필드 개수만큼의 embedding parameter를 선언합니다.
+class FieldAwareFactorizationMachine(nn.Module):
+    def __init__(self, field_dims: np.ndarray, embed_dim: int):
+        super().__init__()
+        self.num_fields = len(field_dims)
+        self.input_dim = sum(field_dims)
+        self.embeddings = torch.nn.ModuleList([
+            torch.nn.Embedding(self.input_dim, embed_dim) for _ in range(self.num_fields)
+        ])
+        [torch.nn.init.xavier_uniform_(embedding.weight.data) for embedding in self.embeddings]
+
+    def forward(self, x: torch.Tensor):
+        xs = [self.embeddings[i](x) for i in range(self.num_fields)]
+        # 매번 사전에 정의된 필드만으로 계산이 되는 것을 확인할 수 있음
+        ix = [xs[j][:, i] * xs[i][:, j] for i in range(self.num_fields - 1) for j in range(i + 1, self.num_fields)]
+        ix = torch.stack(ix, dim=1)
+        return ix

--- a/src/models/FFM/DeepFFM_model.py
+++ b/src/models/FFM/DeepFFM_model.py
@@ -1,0 +1,14 @@
+import numpy as np
+import torch
+import torch.nn as nn
+
+
+# FM모델 등에서 활용되는 선형 결합 부분을 정의합니다.
+class FeaturesLinear(nn.Module):
+    def __init__(self, field_dims: np.ndarray, output_dim: int=1):
+        super().__init__()
+        self.fc = torch.nn.Embedding(sum(field_dims), output_dim)
+        self.bias = torch.nn.Parameter(torch.zeros((output_dim,)))
+
+    def forward(self, x: torch.Tensor):
+        return torch.sum(self.fc(x), dim=1) + self.bias

--- a/src/utils.py
+++ b/src/utils.py
@@ -54,6 +54,8 @@ def models_load(args, data):
         model = DeepCoNN(args, data).to(args.device)
     elif args.model=='CatBoost':
         model = CatBoostModel(args)
+    elif args.model=='DeepFFM':
+        model = DeepFFM(args, data).to(args.device)
     else:
         raise ValueError('MODEL is not exist : select model in [FM,FFM,NCF,WDN,DCN,CNN_FM,DeepCoNN,CatBoost]')
     return model

--- a/sweep/FFM_sweep.yaml
+++ b/sweep/FFM_sweep.yaml
@@ -1,0 +1,25 @@
+program: main.py
+
+method: bayes
+
+name: FFM-sweep
+
+metric:
+  name: Valid Loss
+  goal: minimize
+
+parameters:
+  model:
+    values: ['FFM']
+
+  lr:
+    values: [0.1, 0.01, 0.001]
+
+  batch_size:
+    values: [32, 64, 128]
+
+  embed_dim:
+    values: [8, 16, 32]
+
+  epochs:
+    values: [10, 20, 30, 50]


### PR DESCRIPTION
## Overview
- 기존에 있던 FFM 모델에 DNN(Deep Component)를 추가해서 DeepFFM  모델을 만들었습니다

## Change Log
- 

## To Reviewer
- DeepFM과 비슷하게 FFM과 DNN(Deep Component)가 같은 임베딩을 공유합니다. 하지만 FM과 다르게 FFM은 필드 별로 임베딩이 있기 때문에 DNN(Deep Component)에 입력으로 하나의 임베딩이 아니라, 여러개의 임베딩이 나옵니다. 따라서 이들을 평균을 내는 방법과, 더하는 방식, 곱하는 방식으로 기본 세팅으로 모델 학습을 진행해봤습니다. 
![image](https://github.com/boostcampaitech6/level1-bookratingprediction-recsys-02/assets/77473684/ea1ffa0c-98e8-4fb7-b2e2-e6db59d0b397)


![image](https://github.com/boostcampaitech6/level1-bookratingprediction-recsys-02/assets/77473684/8d9d3509-69bb-4938-b372-b2e1e7bd1057)
```python
avg_xs = torch.stack(xs, dim=0).mean(dim=0)
```
위 코드에 각각 mean과 sum, prod를 사용했습니다. 
- mean: 2.4645
- sum: 2.4665
- prod: 2.4829

## 실험 결과
- DNN(Deep Component)를 추가하면 유의미한 성능 개선이 있을 것이라고 생각했는데 기존 2.47에서 큰 성능 개선이 없었습니다. 
- mean이 sum이나 prod에 비해 높은 성능이 나온 이유는 더하기나 곱하기로 임베딩 값을 합치면 값이 커집니다. 
- 이 커진 값을 고려해서 임베딩이 학습되면서 같은 임베딩을 공유하는 FFM의 학습을 방해하는 것으로 판단됩니다. 

## 추가로 실험해볼것
- FFM과 DNN(Deep Component)가 임베딩을 공유하지 않도록 하기
- 평균 계산 없이 전체 concat

## Issue Tags
- Closed: #52 