### PR TITLE
feat: ncf using context info #61 

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import argparse
 import pandas as pd
 from src.utils import Logger, Setting, models_load, parse_args, parse_args_boolean
 from src.data import context_data_load, context_data_split, context_data_loader
-from src.data import dl_data_load, dl_data_split, dl_data_loader
+from src.data import dl_data_load, dl_data_split, dl_data_loader, context_dl_data_load
 from src.data import image_data_load, image_data_split, image_data_loader
 from src.data import text_data_load, text_data_split, text_data_loader
 from src.data import ml_data_load, ml_data_split
@@ -22,6 +22,8 @@ def main(args):
         data = context_data_load(args)
     elif args.model in ('NCF', 'WDN', 'DCN'):
         data = dl_data_load(args)
+    elif args.model in ('cNCF', 'cNCF-v2', 'cNCF-v3'):
+        data = context_dl_data_load(args)
     elif args.model == 'CNN_FM':
         data = image_data_load(args)
     elif args.model == 'DeepCoNN':
@@ -40,10 +42,10 @@ def main(args):
         data = context_data_split(args, data)
         data = context_data_loader(args, data)
 
-    elif args.model in ('NCF', 'WDN', 'DCN'):
+    elif args.model in ('NCF', 'cNCF', 'cNCF-v2', 'cNCF-v3', 'WDN', 'DCN'):
         data = dl_data_split(args, data)
         data = dl_data_loader(args, data)
-
+        
     elif args.model=='CNN_FM':
         data = image_data_split(args, data)
         data = image_data_loader(args, data)
@@ -136,7 +138,7 @@ if __name__ == "__main__":
     ############### BASIC OPTION
     arg('--data_path', type=str, default='data/', help='Data path를 설정할 수 있습니다.')
     arg('--saved_model_path', type=str, default='./saved_models', help='Saved Model path를 설정할 수 있습니다.')
-    arg('--model', type=str, choices=['FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'CatBoost', 'DeepFFM', 'XGBoost'],
+    arg('--model', type=str, choices=['FM', 'FFM', 'NCF', 'cNCF', 'cNCF-v2', 'cNCF-v3', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'CatBoost', 'DeepFFM', 'XGBoost'],
                                 help='학습 및 예측할 모델을 선택할 수 있습니다.')
     arg('--data_shuffle', type=bool, default=True, help='데이터 셔플 여부를 조정할 수 있습니다.')
     arg('--test_size', type=float, default=0.2, help='Train/Valid split 비율을 조정할 수 있습니다.')

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,5 +1,5 @@
 from .context_data import context_data_load, context_data_split, context_data_loader
-from .dl_data import dl_data_load, dl_data_split, dl_data_loader
+from .dl_data import dl_data_load, dl_data_split, dl_data_loader, context_dl_data_load
 from .image_data import image_data_load, image_data_split, image_data_loader
 from .text_data import text_data_load, text_data_split, text_data_loader
 from .ml_context_data import ml_data_load, ml_data_split

--- a/src/data/dl_data.py
+++ b/src/data/dl_data.py
@@ -102,3 +102,153 @@ def dl_data_loader(args, data):
     data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
 
     return data
+
+
+### context data preprocessing for dl_model
+def age_map(x: int) -> int:
+    x = int(x)
+    if x < 20:
+        return 1
+    elif x >= 20 and x < 30:
+        return 2
+    elif x >= 30 and x < 40:
+        return 3
+    elif x >= 40 and x < 50:
+        return 4
+    elif x >= 50 and x < 60:
+        return 5
+    else:
+        return 6
+
+
+
+def process_context_data(users, books, ratings1, ratings2):
+    """
+    Parameters
+    ----------
+    users : pd.DataFrame
+        users.csv를 인덱싱한 데이터
+    books : pd.DataFrame
+        books.csv를 인덱싱한 데이터
+    ratings1 : pd.DataFrame
+        train 데이터의 rating
+    ratings2 : pd.DataFrame
+        test 데이터의 rating
+    ----------
+    """
+
+    users['location'] = users['location'].str.replace(r'[^0-9a-zA-Z:,]', '', regex=True) # 특수문자 제거
+    users['location_city'] = users['location'].apply(lambda x: x.split(',')[0])
+    users['location_state'] = users['location'].apply(lambda x: x.split(',')[1])
+    users['location_country'] = users['location'].apply(lambda x: x.split(',')[2])
+    
+    users = users.replace('na', np.nan) #특수문자 제거로 n/a가 na로 바뀌게 되었습니다. 따라서 이를 컴퓨터가 인식할 수 있는 결측값으로 변환합니다.
+    users = users.replace('', np.nan) # 일부 경우 , , ,으로 입력된 경우가 있었으므로 이런 경우에도 결측값으로 변환합니다.
+    users = users.drop(['location'], axis=1)
+
+    categories = ['history', 'biography', 'garden','crafts','physics','adventure','music','fiction','nonfiction','science','science fiction','social','homicide',
+                  'sociology','disease','religion','christian','philosophy','psycholog','mathemat','agricult','environmental',
+                  'business','poetry','drama','literary','travel','motion picture','children','cook','literature','electronic',
+                  'humor','animal','bird','photograph','computer','house','ecology','family','architect','camp','criminal','language','india']
+
+    for category in categories:
+        books.loc[books[books['category'].str.contains(category,na=False)].index,'category'] = category
+        
+    ratings = pd.concat([ratings1, ratings2]).reset_index(drop=True)
+
+    # 인덱싱 처리된 데이터 조인
+    context_df = ratings.merge(users, on='user_id', how='left').merge(books[['isbn', 'category', 'publisher', 'language', 'book_author']], on='isbn', how='left')
+    train_df = ratings1.merge(users, on='user_id', how='left').merge(books[['isbn', 'category', 'publisher', 'language', 'book_author']], on='isbn', how='left')
+    test_df = ratings2.merge(users, on='user_id', how='left').merge(books[['isbn', 'category', 'publisher', 'language', 'book_author']], on='isbn', how='left')
+
+    # 인덱싱 처리
+    loc_city2idx = {v:k for k,v in enumerate(context_df['location_city'].unique())}
+    loc_state2idx = {v:k for k,v in enumerate(context_df['location_state'].unique())}
+    loc_country2idx = {v:k for k,v in enumerate(context_df['location_country'].unique())}
+
+    train_df['location_city'] = train_df['location_city'].map(loc_city2idx)
+    train_df['location_state'] = train_df['location_state'].map(loc_state2idx)
+    train_df['location_country'] = train_df['location_country'].map(loc_country2idx)
+    test_df['location_city'] = test_df['location_city'].map(loc_city2idx)
+    test_df['location_state'] = test_df['location_state'].map(loc_state2idx)
+    test_df['location_country'] = test_df['location_country'].map(loc_country2idx)
+
+    train_df['age'] = train_df['age'].fillna(int(train_df['age'].mean()))
+    train_df['age'] = train_df['age'].apply(age_map)
+    test_df['age'] = test_df['age'].fillna(int(test_df['age'].mean()))
+    test_df['age'] = test_df['age'].apply(age_map)
+
+    # book 파트 인덱싱
+    category2idx = {v:k for k,v in enumerate(context_df['category'].unique())}
+    publisher2idx = {v:k for k,v in enumerate(context_df['publisher'].unique())}
+    language2idx = {v:k for k,v in enumerate(context_df['language'].unique())}
+    author2idx = {v:k for k,v in enumerate(context_df['book_author'].unique())}
+
+    train_df['category'] = train_df['category'].map(category2idx)
+    train_df['publisher'] = train_df['publisher'].map(publisher2idx)
+    train_df['language'] = train_df['language'].map(language2idx)
+    train_df['book_author'] = train_df['book_author'].map(author2idx)
+    test_df['category'] = test_df['category'].map(category2idx)
+    test_df['publisher'] = test_df['publisher'].map(publisher2idx)
+    test_df['language'] = test_df['language'].map(language2idx)
+    test_df['book_author'] = test_df['book_author'].map(author2idx)
+
+    idx = {
+        "loc_city2idx":loc_city2idx,
+        "loc_state2idx":loc_state2idx,
+        "loc_country2idx":loc_country2idx,
+        "category2idx":category2idx,
+        "publisher2idx":publisher2idx,
+        "language2idx":language2idx,
+        "author2idx":author2idx,
+    }
+
+    return idx, train_df, test_df
+
+def context_dl_data_load(args):
+    ######################## DATA LOAD
+    users = pd.read_csv(args.data_path + 'users.csv')
+    books = pd.read_csv(args.data_path + 'books.csv')
+    train = pd.read_csv(args.data_path + 'train_ratings.csv')
+    test = pd.read_csv(args.data_path + 'test_ratings.csv')
+    sub = pd.read_csv(args.data_path + 'sample_submission.csv')
+
+    ids = pd.concat([train['user_id'], sub['user_id']]).unique()
+    isbns = pd.concat([train['isbn'], sub['isbn']]).unique()
+
+    idx2user = {idx:id for idx, id in enumerate(ids)}
+    idx2isbn = {idx:isbn for idx, isbn in enumerate(isbns)}
+
+    user2idx = {id:idx for idx, id in idx2user.items()}
+    isbn2idx = {isbn:idx for idx, isbn in idx2isbn.items()}
+
+    train['user_id'] = train['user_id'].map(user2idx)
+    sub['user_id'] = sub['user_id'].map(user2idx)
+    test['user_id'] = test['user_id'].map(user2idx)
+    users['user_id'] = users['user_id'].map(user2idx)
+
+    train['isbn'] = train['isbn'].map(isbn2idx)
+    sub['isbn'] = sub['isbn'].map(isbn2idx)
+    test['isbn'] = test['isbn'].map(isbn2idx)
+    books['isbn'] = books['isbn'].map(isbn2idx)
+    
+    idx, context_train, context_test = process_context_data(users, books, train, test)
+    field_dims = np.array([len(user2idx), len(isbn2idx),
+                            6, len(idx['loc_city2idx']), len(idx['loc_state2idx']), len(idx['loc_country2idx']),
+                            len(idx['category2idx']), len(idx['publisher2idx']), len(idx['language2idx']), len(idx['author2idx'])], dtype=np.uint32)
+
+    data = {
+            'train':context_train,
+            'test':context_test.drop(['rating'], axis=1),
+            'field_dims':field_dims,
+            'users':users,
+            'books':books,
+            'sub':sub,
+            'idx2user':idx2user,
+            'idx2isbn':idx2isbn,
+            'user2idx':user2idx,
+            'isbn2idx':isbn2idx,
+            }
+
+
+    return data

--- a/src/models/NCF/NCF_model.py
+++ b/src/models/NCF/NCF_model.py
@@ -94,7 +94,7 @@ class NeuralCollaborativeFiltering(nn.Module):
         return x
 
 
-# MLP의 output과 context latent factor를 concat한다. -> skip connection에서 영감을 받음...
+# cNCF-v2: MLP의 output과 context latent factor를 concat한다. -> skip connection에서 영감을 받음...
 class ConcatNeuralCollaborativeFiltering(nn.Module):
     def __init__(self, args, data):
         super().__init__()
@@ -126,7 +126,7 @@ class ConcatNeuralCollaborativeFiltering(nn.Module):
         
         return x
     
-# user, item, context latent factor를 활용하여 GMF를 구현합니다.
+# cNCF-v3: user, item, context latent factor를 활용하여 GMF를 구현합니다.
 class ContextGMFNeuralCollaborativeFiltering(nn.Module):
     def __init__(self, args, data):
         super().__init__()

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,4 +1,8 @@
 from .WDN.WDN_model import WideAndDeepModel
 from .GBDT.CatBoost_model import CatBoostModel
-from .NCF.NCF_model import NeuralCollaborativeFiltering
+from .NCF.NCF_model import NeuralCollaborativeFiltering, ConcatNeuralCollaborativeFiltering, ContextGMFNeuralCollaborativeFiltering
 from .GBDT.XGBoost_model import XGBoostModel
+from .CNN_FM.CNN_FM_model import CNN_FM
+from .DeepFFM.DeepFFM_model import DeepFFM
+from .FFM.FFM_model import FieldAwareFactorizationMachineModel
+from .FM.FM_model import FactorizationMachineModel

--- a/src/utils.py
+++ b/src/utils.py
@@ -53,16 +53,20 @@ def models_load(args, data):
         model = FactorizationMachineModel(args, data).to(args.device)
     elif args.model=='FFM':
         model = FieldAwareFactorizationMachineModel(args, data).to(args.device)
-    elif args.model=='NCF':
+    elif args.model in ('NCF', 'cNCF'):
         model = NeuralCollaborativeFiltering(args, data).to(args.device)
+    elif args.model=='cNCF-v2':
+        model = ConcatNeuralCollaborativeFiltering(args, data).to(args.device)
+    elif args.model=='cNCF-v3':
+        model = ContextGMFNeuralCollaborativeFiltering(args, data).to(args.device)
     elif args.model=='WDN':
         model = WideAndDeepModel(args, data).to(args.device)
-    elif args.model=='DCN':
-        model = DeepCrossNetworkModel(args, data).to(args.device)
+    # elif args.model=='DCN':
+    #     model = DeepCrossNetworkModel(args, data).to(args.device)
     elif args.model=='CNN_FM':
         model = CNN_FM(args, data).to(args.device)
-    elif args.model=='DeepCoNN':
-        model = DeepCoNN(args, data).to(args.device)
+    # elif args.model=='DeepCoNN':
+    #     model = DeepCoNN(args, data).to(args.device)
     elif args.model=='CatBoost':
         model = CatBoostModel(args)
     elif args.model=='DeepFFM':


### PR DESCRIPTION
## Overview
- context를 정보를 활용하여 NCF모델 설계 및 실험

## Change Log
- 기존 context_data_load 부분과 preprocessing_context_data를 리팩토링하여 NCF의 context데이터 불러오는데 활용했습니다.
- cNCF: MLP에 user, item latent factor 뿐만 아니라 context latent factor도 같이 입력으로 주었습니다.
- cNCF-v2: cNCF에서 MLP의 출력 x, GMF와 context latent factor를 concat해주었습니다. 또한 FC layer를 더 추가했습니다.
- cNCF-v3: cNCF에서 GMF에 user, item, context latent factor를 pairwise-product를 진행해주었습니다.

## To Reviewer
- 자세한 #61의 모델 아키텍처를 참고하시면 될것 같습니다.

## Issue Tags
- Closed: #61
- See also: #61 